### PR TITLE
rendering both boats & orders in admin panel

### DIFF
--- a/client/components/allUsersAdminView.js
+++ b/client/components/allUsersAdminView.js
@@ -1,15 +1,41 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { getAllUsers } from '../store';
+import {
+  getAllUsers,
+  getAllBoats,
+  getAllOrders,
+  increaseQuantity,
+  decreaseQuantity,
+} from '../store';
 import { Link } from 'react-router-dom';
+import { costDisplay } from './utils';
 
 class AllUsersAdminView extends Component {
+  constructor() {
+    super();
+    this.increase = this.increase.bind(this);
+    this.decrease = this.decrease.bind(this);
+  }
   componentDidMount() {
     this.props.getAllUsers();
+    this.props.getAllBoats();
+    this.props.getAllOrders();
     console.log('hello', this.props.getAllUsers());
+  }
+
+  increase() {
+    this.props.increaseQuantity(this.props.match.params.id);
+  }
+  decrease() {
+    this.props.decreaseQuantity(this.props.match.params.id);
   }
   render() {
     const { users } = this.props;
+    const { boats } = this.props;
+    const { orders } = this.props;
+    const disableIncrease = boats.quantity === 100;
+    const disableDecrease = boats.quantity === 0;
+
     // console.log('state', this.state);
     console.log('in admin panel');
     console.log('users', this.props.users);
@@ -33,8 +59,56 @@ class AllUsersAdminView extends Component {
           })}
         </ul>
         <h1>All products: </h1>
+        <ul>
+          {boats.map(boat => {
+            return (
+              <li key={boat.id}>
+                <Link to={`/boats/${boat.id}`}>
+                  <p>{boat.name}</p>
+                </Link>
+                <img src={boat.imageUrl} width="190" height="190" />
 
+                <p>Cost: {costDisplay(boat.cost)}</p>
+                <p>Inventory: {boat.inventory}</p>
+                <button
+                  type="button"
+                  size="small"
+                  color="primary"
+                  disabled={disableDecrease}
+                  onClick={this.decrease}
+                >
+                  Decrease
+                </button>
+                <button
+                  type="button"
+                  size="small"
+                  color="primary"
+                  disabled={disableIncrease}
+                  onClick={this.increase}
+                >
+                  Increase
+                </button>
+              </li>
+            );
+          })}
+        </ul>
         <h1>All carts: </h1>
+        <ul>
+          {orders.map(order => {
+            return (
+              <li key={order.id}>
+                <h2>User ID: </h2>
+                <h3>{order.userId}</h3>
+                <h2>Order ID: </h2>
+                <h3>{order.id}</h3>
+                <h2>Order status: </h2>
+                <h3>{order.status}</h3>
+                <h2>Order total: </h2>
+                <h3>{order.total}</h3>
+              </li>
+            );
+          })}
+        </ul>
       </div>
     );
   }
@@ -42,14 +116,18 @@ class AllUsersAdminView extends Component {
 
 const mapState = state => {
   return {
-    // boats: state.boat.allBoats,
+    boats: state.boat.allBoats,
     users: state.users,
+    orders: state.orders,
   };
 };
 const mapDispatch = dispatch => {
   return {
-    // getAllBoats: () => dispatch(getAllBoats()),
+    getAllBoats: () => dispatch(getAllBoats()),
     getAllUsers: () => dispatch(getAllUsers()),
+    getAllOrders: () => dispatch(getAllOrders()),
+    increaseQuantity: id => dispatch(increaseQuantity(id)),
+    decreaseQuantity: id => dispatch(decreaseQuantity(id)),
   };
 };
 

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -6,8 +6,16 @@ import user from './user';
 import users from './users';
 import boat from './boat';
 import order, { userOrder } from './order';
+import orders from './orders';
 
-const reducer = combineReducers({ user, users, boat, order, userOrder });
+const reducer = combineReducers({
+  user,
+  users,
+  boat,
+  order,
+  orders,
+  userOrder,
+});
 const middleware = composeWithDevTools(
   applyMiddleware(thunkMiddleware, createLogger({ collapsed: true }))
 );
@@ -18,3 +26,4 @@ export * from './user';
 export * from './boat';
 export * from './order';
 export * from './users';
+export * from './orders';

--- a/client/store/orders.js
+++ b/client/store/orders.js
@@ -1,0 +1,37 @@
+import axios from 'axios';
+
+/**
+ * ACTION TYPES
+ */
+const GET_ORDERS = 'GET_ORDERS';
+
+/**
+ * ACTION CREATORS
+ */
+
+const getOrders = orders => ({
+  type: GET_ORDERS,
+  orders,
+});
+
+/**
+ * THUNK CREATORS
+ */
+
+export const getAllOrders = () => async dispatch => {
+  try {
+    const { data } = await axios.get('/api/orders');
+    dispatch(getOrders(data));
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export default function(orders = [], action) {
+  switch (action.type) {
+    case GET_ORDERS:
+      return action.orders;
+    default:
+      return orders;
+  }
+}


### PR DESCRIPTION
referencing ticket #120 & #99 

- [ ] products are visible in admin panel

- [ ]  orders are visible in admin panel


need to
- [ ] make both products & orders edit-able

- [ ] would like to separate users/ orders/ products by links. pages has gotten too long

will continue tomorrow 